### PR TITLE
Moved cast.hpp file from Conversion library. It was decided that this fi...

### DIFF
--- a/include/boost/cast.hpp
+++ b/include/boost/cast.hpp
@@ -1,0 +1,20 @@
+//  boost cast.hpp header file
+//
+//  (C) Copyright Antony Polukhin 2014.
+//
+//  Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//  See http://www.boost.org/libs/conversion for Documentation.
+
+// This is a DEPRECATED header file!
+// Use <boost/polymorphic_cast.hpp> or <boost/numeric/conversion/cast.hpp> instead
+
+#ifndef BOOST_CAST_HPP
+#define BOOST_CAST_HPP
+
+# include <boost/polymorphic_cast.hpp>
+# include <boost/numeric/conversion/cast.hpp>
+
+#endif  // BOOST_CAST_HPP


### PR DESCRIPTION
...le must be in NumericCast library to reduce dependencies.

See the "[boost] conversion, cast.hpp (Was: [modularization] Recommendations)" discussion for more info.
