### PR TITLE
Fix compilation on lastest MSVC

### DIFF
--- a/include/boost/numeric/conversion/detail/converter.hpp
+++ b/include/boost/numeric/conversion/detail/converter.hpp
@@ -12,6 +12,7 @@
 
 #include <functional>
 
+#include "boost/functional.hpp"
 #include "boost/numeric/conversion/detail/meta.hpp"
 #include "boost/numeric/conversion/detail/conversion_traits.hpp"
 #include "boost/numeric/conversion/bounds.hpp"
@@ -450,10 +451,13 @@ namespace boost { namespace numeric { namespace convdetail
   // Trivial Converter : used when (cv-unqualified) T == (cv-unqualified)  S
   //
   template<class Traits>
-  struct trivial_converter_impl : public dummy_range_checker<Traits>
+  struct trivial_converter_impl : public boost::functional::detail::unary_function<  BOOST_DEDUCED_TYPENAME Traits::argument_type
+                                                              ,BOOST_DEDUCED_TYPENAME Traits::result_type
+                                                            >
+                                 ,public dummy_range_checker<Traits>
   {
     typedef Traits traits ;
-    
+
     typedef typename Traits::source_type   source_type   ;
     typedef typename Traits::argument_type argument_type ;
     typedef typename Traits::result_type   result_type   ;
@@ -468,7 +472,10 @@ namespace boost { namespace numeric { namespace convdetail
   // Rounding Converter : used for float to integral conversions.
   //
   template<class Traits,class RangeChecker,class RawConverter,class Float2IntRounder>
-  struct rounding_converter : public RangeChecker
+  struct rounding_converter : public boost::functional::detail::unary_function<  BOOST_DEDUCED_TYPENAME Traits::argument_type
+                                                          ,BOOST_DEDUCED_TYPENAME Traits::result_type
+                                                        >
+                             ,public RangeChecker
                              ,public Float2IntRounder
                              ,public RawConverter
   {
@@ -495,7 +502,10 @@ namespace boost { namespace numeric { namespace convdetail
   // Non-Rounding Converter : used for all other conversions.
   //
   template<class Traits,class RangeChecker,class RawConverter>
-  struct non_rounding_converter : public RangeChecker
+  struct non_rounding_converter : public boost::functional::detail::unary_function< BOOST_DEDUCED_TYPENAME Traits::argument_type
+                                                             ,BOOST_DEDUCED_TYPENAME Traits::result_type
+                                                           >
+                                 ,public RangeChecker
                                  ,public RawConverter
   {
     typedef RangeChecker RangeCheckerBase ;


### PR DESCRIPTION
std::unary_function has been removed from C++ 17 standard so it does not compile anymore on MSVC

Setup :
Lastest MSVC
C++ 2017

Thanks to Mylerius for the help.