### PR TITLE
Link to latest version of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ The Boost Numeric Conversion library is a collection of tools to describe and pe
 
 The documentation for the library can be found [here][2]
 
-[1]: http://www.boost.org/doc/libs/1_65_0/libs/numeric/conversion/doc/html/boost_numericconversion/definitions.html#boost_numericconversion.definitions.numeric_types
-[2]: http://www.boost.org/doc/libs/1_65_0/libs/numeric/conversion/doc/html/index.html#numeric_conversion.overview
+[1]: http://www.boost.org/doc/libs/release/libs/numeric/conversion/doc/html/boost_numericconversion/definitions.html#boost_numericconversion.definitions.numeric_types
+[2]: http://www.boost.org/doc/libs/release/libs/numeric/conversion/doc/html/index.html#numeric_conversion.overview


### PR DESCRIPTION
Putting 'release' instead of the version number will redirect to the latest documentation.