### PR TITLE
Tests: Fix C1128 error on msvc-14.1+

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -19,7 +19,7 @@ project numeric_conversion_unit_tests
 test-suite minimal 
     :
         [ run bounds_test.cpp ]
-        [ run traits_test.cpp ]
+        [ run traits_test.cpp : : : <toolset>msvc:<cxxflags>/bigobj ]
         [ run converter_test.cpp ]
         [ run udt_support_test.cpp ]
         [ run numeric_cast_test.cpp ]


### PR DESCRIPTION
traits_test fails on msvc-14.1+ in 64bit debug mode with C1128 error.

The `/bigobj` option should be in every supported msvc version (vs2005+).

Fixes #15