### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.NumericConversion is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostNumericConversion)
+
+add_library(boost_numeric_conversion INTERFACE)
+add_library(Boost::numeric_conversion ALIAS boost_numeric_conversion)
+
+target_include_directories(boost_numeric_conversion INTERFACE include)
+
+target_link_libraries(boost_numeric_conversion
+    INTERFACE
+        Boost::config
+        Boost::conversion
+        Boost::core
+        Boost::mpl
+        Boost::preprocessor
+        Boost::throw_exception
+        Boost::type_traits
+)
+


### PR DESCRIPTION
- CMake file only supports `add_subdirectory` workflow.
- Provides target `Boost::numeric_conversion` to "link" against (effectively providing the include directory of numeric_conversion and information about its dependencies).
- Doesn't support installation (That is taken care of via b2).

Note: As the unit test depend on Boost.Test, which in turn depends on numeric_conversion, I think it doesn't make sense - for now - to run the unit tests from cmake even though it would be possible in principle by relying on a preinstalled version of Boost.Test.
