### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/numeric/conversion/cast.hpp
+++ b/include/boost/numeric/conversion/cast.hpp
@@ -23,7 +23,7 @@
 
 #include <boost/detail/workaround.hpp>
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x582))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x582))
 
 #  include<boost/numeric/conversion/detail/old_numeric_cast.hpp>
 

--- a/include/boost/numeric/conversion/detail/converter.hpp
+++ b/include/boost/numeric/conversion/detail/converter.hpp
@@ -561,7 +561,7 @@ namespace boost { namespace numeric { namespace convdetail
           >
   struct get_converter_impl
   {
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT( 0x0561 ) )
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT( 0x0561 ) )
     // bcc55 prefers sometimes template parameters to be explicit local types.
     // (notice that is is illegal to reuse the names like this)
     typedef Traits           Traits ;

--- a/include/boost/numeric/conversion/detail/meta.hpp
+++ b/include/boost/numeric/conversion/detail/meta.hpp
@@ -25,7 +25,7 @@ namespace boost { namespace numeric { namespace convdetail
    template< class T1, class T2>
    struct equal_to
    {
-   #if !defined(__BORLANDC__)
+   #if !defined(BOOST_BORLANDC)
    
        enum { x = ( BOOST_MPL_AUX_VALUE_WKND(T1)::value == BOOST_MPL_AUX_VALUE_WKND(T2)::value ) };
            

--- a/include/boost/numeric/conversion/detail/old_numeric_cast.hpp
+++ b/include/boost/numeric/conversion/detail/old_numeric_cast.hpp
@@ -231,7 +231,7 @@ namespace boost
 #  pragma warning(push)
 #  pragma warning(disable : 4018)
 #  pragma warning(disable : 4146)
-#elif defined(__BORLANDC__)
+#elif defined(BOOST_BORLANDC)
 #  pragma option push -w-8041
 # endif
 
@@ -248,7 +248,7 @@ namespace boost
 
 # if BOOST_MSVC
 #  pragma warning(pop)
-#elif defined(__BORLANDC__)
+#elif defined(BOOST_BORLANDC)
 #  pragma option pop
 # endif
   } // namespace detail
@@ -285,7 +285,7 @@ namespace boost
 # if BOOST_MSVC
 #  pragma warning(push)
 #  pragma warning(disable : 4018)
-#elif defined(__BORLANDC__)
+#elif defined(BOOST_BORLANDC)
 #pragma option push -w-8012
 # endif
         if ((arg < 0 && !result_traits::is_signed)  // loss of negative range
@@ -293,7 +293,7 @@ namespace boost
              || arg > (result_traits::max)())            // overflow
 # if BOOST_MSVC
 #  pragma warning(pop)
-#elif defined(__BORLANDC__)
+#elif defined(BOOST_BORLANDC)
 #pragma option pop
 # endif
 #endif

--- a/test/bounds_test.cpp
+++ b/test/bounds_test.cpp
@@ -13,7 +13,7 @@
 
 #include "boost/numeric/conversion/bounds.hpp"
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 #pragma hdrstop
 #endif
 

--- a/test/converter_test.cpp
+++ b/test/converter_test.cpp
@@ -22,7 +22,7 @@
 //
 // Borland 5.5 lacks the following math overloads
 //
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x551)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x551)
 namespace std
 {
 
@@ -37,7 +37,7 @@ inline long double floor (long double x) { return std::floorl(x); }
 #include "boost/numeric/conversion/converter.hpp"
 #include "boost/numeric/conversion/cast.hpp"
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 #pragma hdrstop
 #endif
 

--- a/test/test_helpers.cpp
+++ b/test/test_helpers.cpp
@@ -118,7 +118,7 @@ class numeric_limits<MyUDT::MyFloat> : public numeric_limits<double>
 // should be found by koenig loopkup, but some compilers don't do it right
 // so we inyect them into namespace std so ordinary overload resolution
 // can found them.
-#if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP) || defined(__BORLANDC__) || defined(__GNUC__)
+#if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP) || defined(BOOST_BORLANDC) || defined(__GNUC__)
 namespace std {
 using MyUDT::floor ;
 using MyUDT::ceil  ;

--- a/test/traits_test.cpp
+++ b/test/traits_test.cpp
@@ -22,7 +22,7 @@
 #include <boost/numeric/conversion/udt_builtin_mixture.hpp>
 #include <boost/numeric/conversion/is_subranged.hpp>
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 #pragma hdrstop
 #endif
 

--- a/test/udt_support_test.cpp
+++ b/test/udt_support_test.cpp
@@ -14,7 +14,7 @@
 
 #include "boost/numeric/conversion/converter.hpp"
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 #pragma hdrstop
 #endif
 


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.